### PR TITLE
Fix render-readme workflow

### DIFF
--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -23,10 +23,6 @@ jobs:
     steps:
       - name: Checkout repos
         uses: actions/checkout@v2
-        with:
-          ref: main
-          fetch-depth: 0
-          persist-credentials: false # to avoid reusing these credentials when pushing
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -47,11 +47,4 @@ jobs:
           git config --local user.name "GitHub Action"
           git add README.md
           git diff-index --quiet HEAD || git commit -m "Automatic readme update"
-   
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.PAT_TIBO }}
-          branch: 'main'
-          force: true
-          
+          git push origin || echo "No changes to push"

--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -17,7 +17,7 @@ jobs:
   render-readme:
     runs-on: macos-latest
     env:
-      GITHUB_PAT: ${{ secrets.PAT_TIBO }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repos
         uses: actions/checkout@v2

--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -38,7 +38,7 @@ jobs:
  
       - name: Compile the readme
         run: |
-          rmarkdown::render("readme.Rmd")
+          rmarkdown::render("README.Rmd")
         shell: Rscript {0}
         
       - name: Commit files

--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -9,8 +9,6 @@ name: render-readme
 on:
   workflow_dispatch:
   push:
-    branches:
-      - 'main'
     paths:
       - 'README.Rmd'
 

--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - 'main'
     paths:
-      - 'readme.Rmd'
+      - 'README.Rmd'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 # Important: ubuntu-latest is not set up properly for R, so use macOS

--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -15,7 +15,6 @@ on:
       - 'README.Rmd'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
-# Important: ubuntu-latest is not set up properly for R, so use macOS
 jobs:
   render-readme:
     runs-on: macos-latest


### PR DESCRIPTION
I noticed that the workflow didn't start automatically, and when manually triggered from another branch, it was still running in `main`. This PR:

- fixes the trigger on `main`
- adds a trigger to run on pushes in all branches (particularly useful when submitting PR)
- removes external action to push as:
  - it is not necessary
  - it is more secure to avoid external actions when unnecessary as their maintainer could theoretically modify them for nefarious purposes (unless it is pinned to a specific commit)
  - it is not safe to force push as other commits might have been pushes while this workflow was running
- uses the default `GITHUB_TOKEN` PAT. This is safer as it has limited scope and permissions, thereby limiting the damage if it got stolen (as opposed to your own PAT, which might give an attacker access to all your repos) 

You can see a [somewhat similar workflow in the fundiversity repo](https://github.com/Bisaloo/fundiversity/blob/main/.github/workflows/render-readme.yaml) and verify that it works fine.