### PR TITLE
Fix subsetting by column with passing just one argument to [

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,9 @@
 
 ## Bug fixes
 
-
-
+* `[.linelist()` now works to subset by column when including just one argument 
+(#54, @Bisaloo). E.g., `x[1]`. As an indirect effect, this also improves
+compatibility with dplyr verbs that rely on this method (#51).
 
 # linelist 0.0.1
 

--- a/R/square_bracket.R
+++ b/R/square_bracket.R
@@ -74,10 +74,10 @@
   # the drop_linelist() function
 
   lost_action <- get_lost_tags_action()
-  
+
   # Handle the corner case where only 1 arg is passed (x[i]) to subset by column
   n_args <- nargs() - !missing(drop)
-  
+
   if (n_args <= 2L) {
     # Avoid "'drop' argument will be ignored" warning in [.data.frame() from our
     # default value. When we subset this way, drop is always considered to be
@@ -103,8 +103,6 @@
   out
 }
 
-
-
 #' @export
 #'
 #' @rdname sub_linelist
@@ -116,8 +114,6 @@
   out <- restore_tags(out, old_tags, lost_action)
   out
 }
-
-
 
 #' @export
 #'

--- a/R/square_bracket.R
+++ b/R/square_bracket.R
@@ -79,9 +79,14 @@
   n_args <- nargs() - !missing(drop)
   
   if (n_args <= 2L) {
-    # Avoid "'drop' argument will be ignored" warning in [.data.frame. When we 
-    # subset this way, drop is always considered to be TRUE
-    out <- drop_linelist(x)[i]
+    # Avoid "'drop' argument will be ignored" warning in [.data.frame() from our
+    # default value. When we subset this way, drop is always considered to be
+    # TRUE. We let warnings from user-specified drop values surface.
+    if (missing(drop)) {
+      out <- drop_linelist(x)[i]
+    } else {
+      out <- drop_linelist(x)[i, drop = drop]
+    }
   } else {
     out <- drop_linelist(x)[i, j, drop = drop]
   }

--- a/R/square_bracket.R
+++ b/R/square_bracket.R
@@ -74,9 +74,19 @@
   # the drop_linelist() function
 
   lost_action <- get_lost_tags_action()
+  
+  # Handle the corner case where only 1 arg is passed (x[i]) to subset by column
+  n_args <- nargs() - !missing(drop)
+  
+  if (n_args <= 2L) {
+    # Avoid "'drop' argument will be ignored" warning in [.data.frame. When we 
+    # subset this way, drop is always considered to be TRUE
+    out <- drop_linelist(x)[i]
+  } else {
+    out <- drop_linelist(x)[i, j, drop = drop]
+  }
 
   # Case 1
-  out <- drop_linelist(x)[i, j, drop = drop]
   if (is.null(ncol(out))) {
     return(out)
   }

--- a/tests/testthat/test-square_bracket.R
+++ b/tests/testthat/test-square_bracket.R
@@ -22,8 +22,8 @@ test_that("tests for [ operator", {
 
   lost_tags_action("none", quiet = TRUE)
   expect_identical(x[, 1], make_linelist(cars[, 1, drop = FALSE], id = "speed"))
-  
-  # [ behaves exactly as in the simple data.frame case, including when subset 
+
+  # [ behaves exactly as in the simple data.frame case, including when subset
   # only cols. https://github.com/epiverse-trace/linelist/issues/51
   expect_identical(
     cars[1],
@@ -35,7 +35,7 @@ test_that("tests for [ operator", {
     x[1],
     ignore_attr = TRUE
   )
-  
+
   # Warning about drop is surfaced to the user in this situation *iff* not our
   # default
   expect_no_warning(
@@ -50,8 +50,6 @@ test_that("tests for [ operator", {
     "`drop` argument ignored"
   )
 })
-
-
 
 test_that("tests for [<- operator", {
 
@@ -75,11 +73,6 @@ test_that("tests for [<- operator", {
   x[, 1:2] <- NULL
   expect_identical(ncol(x), 0L)
 })
-
-
-
-
-
 
 test_that("tests for [[<- operator", {
 

--- a/tests/testthat/test-square_bracket.R
+++ b/tests/testthat/test-square_bracket.R
@@ -35,6 +35,20 @@ test_that("tests for [ operator", {
     x[1],
     ignore_attr = TRUE
   )
+  
+  # Warning about drop is surfaced to the user in this situation *iff* not our
+  # default
+  expect_no_warning(
+    x[1]
+  )
+  expect_warning(
+    x[1, drop = FALSE],
+    "'drop' argument will be ignored"
+  )
+  expect_warning(
+    dplyr::as_tibble(x)[1, drop = FALSE],
+    "`drop` argument ignored"
+  )
 })
 
 

--- a/tests/testthat/test-square_bracket.R
+++ b/tests/testthat/test-square_bracket.R
@@ -22,6 +22,19 @@ test_that("tests for [ operator", {
 
   lost_tags_action("none", quiet = TRUE)
   expect_identical(x[, 1], make_linelist(cars[, 1, drop = FALSE], id = "speed"))
+  
+  # [ behaves exactly as in the simple data.frame case, including when subset 
+  # only cols. https://github.com/epiverse-trace/linelist/issues/51
+  expect_identical(
+    cars[1],
+    x[1],
+    ignore_attr = TRUE
+  )
+  expect_identical(
+    dplyr::as_tibble(cars)[1],
+    x[1],
+    ignore_attr = TRUE
+  )
 })
 
 


### PR DESCRIPTION
Fix #51

## Old behaviour

This differed from how `data.frame` and `tibble` work:

``` r
library(linelist)

x <- make_linelist(cars, date_onset = "dist", date_outcome = "speed")

x[1]
#> 
#> // linelist object
#>   speed dist
#> 1     4    2
#> 
#> // tags: date_onset:dist, date_outcome:speed

cars[1]
#>    speed
#> 1      4
#> 2      4
#> 3      7
#> 4      7
#> 5      8
#> 6      9
#> 7     10
#> 8     10
#> 9     10
#> 10    11
#> 11    11
#> 12    12
#> 13    12
#> 14    12
#> 15    12
#> 16    13
#> 17    13
#> 18    13
#> 19    13
#> 20    14
#> 21    14
#> 22    14
#> 23    14
#> 24    15
#> 25    15
#> 26    15
#> 27    16
#> 28    16
#> 29    17
#> 30    17
#> 31    17
#> 32    18
#> 33    18
#> 34    18
#> 35    18
#> 36    19
#> 37    19
#> 38    19
#> 39    20
#> 40    20
#> 41    20
#> 42    20
#> 43    20
#> 44    22
#> 45    23
#> 46    24
#> 47    24
#> 48    24
#> 49    24
#> 50    25
```

<sup>Created on 2023-04-18 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>

## New behaviour

This is consistent with how `data.frame` and `tibble` work

``` r
library(linelist)

x <- make_linelist(cars, date_onset = "dist", date_outcome = "speed")

x[1]
#> Warning in prune_tags(out, lost_action): The following tags have lost their variable:
#>  date_onset:dist
#> 
#> // linelist object
#>    speed
#> 1      4
#> 2      4
#> 3      7
#> 4      7
#> 5      8
#> 6      9
#> 7     10
#> 8     10
#> 9     10
#> 10    11
#> 11    11
#> 12    12
#> 13    12
#> 14    12
#> 15    12
#> 16    13
#> 17    13
#> 18    13
#> 19    13
#> 20    14
#> 21    14
#> 22    14
#> 23    14
#> 24    15
#> 25    15
#> 26    15
#> 27    16
#> 28    16
#> 29    17
#> 30    17
#> 31    17
#> 32    18
#> 33    18
#> 34    18
#> 35    18
#> 36    19
#> 37    19
#> 38    19
#> 39    20
#> 40    20
#> 41    20
#> 42    20
#> 43    20
#> 44    22
#> 45    23
#> 46    24
#> 47    24
#> 48    24
#> 49    24
#> 50    25
#> 
#> // tags: date_outcome:speed

cars[1]
#>    speed
#> 1      4
#> 2      4
#> 3      7
#> 4      7
#> 5      8
#> 6      9
#> 7     10
#> 8     10
#> 9     10
#> 10    11
#> 11    11
#> 12    12
#> 13    12
#> 14    12
#> 15    12
#> 16    13
#> 17    13
#> 18    13
#> 19    13
#> 20    14
#> 21    14
#> 22    14
#> 23    14
#> 24    15
#> 25    15
#> 26    15
#> 27    16
#> 28    16
#> 29    17
#> 30    17
#> 31    17
#> 32    18
#> 33    18
#> 34    18
#> 35    18
#> 36    19
#> 37    19
#> 38    19
#> 39    20
#> 40    20
#> 41    20
#> 42    20
#> 43    20
#> 44    22
#> 45    23
#> 46    24
#> 47    24
#> 48    24
#> 49    24
#> 50    25
```

<sup>Created on 2023-04-18 with [reprex v2.0.2.9000](https://reprex.tidyverse.org)</sup>