### PR TITLE
Remove option to use lost_tags_actions() in pipeline

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -4,11 +4,13 @@ linters: all_linters(
     implicit_integer_linter = NULL,
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
+    library_call_linter = NULL,
     undesirable_function_linter(
       modify_defaults(
         default_undesirable_functions,
         citEntry = "use the more modern bibentry() function",
-        library = NULL # too many false positive in too many files
+        library = NULL, # too many false positive in too many files
+        options = NULL
       )
     ),
     function_argument_linter = NULL,

--- a/.lintr
+++ b/.lintr
@@ -1,12 +1,31 @@
-linters: linters_with_tags(
-    tags = NULL, # include all linters
+linters: all_linters(
+    packages = c("lintr", "etdev"),
     object_name_linter = NULL,
-    undesirable_function_linter = NULL,
     implicit_integer_linter = NULL,
     extraction_operator_linter = NULL,
     todo_comment_linter = NULL,
+    undesirable_function_linter(
+      modify_defaults(
+        default_undesirable_functions,
+        citEntry = "use the more modern bibentry() function",
+        library = NULL # too many false positive in too many files
+      )
+    ),
     function_argument_linter = NULL,
-    # Use minimum R declared in DESCRIPTION or fall back to current R version
+    indentation_linter = NULL, # unstable as of lintr 3.1.0
+    # Use minimum R declared in DESCRIPTION or fall back to current R version.
+    # Install etdev package from https://github.com/epiverse-trace/etdev
     backport_linter(if (length(x <- etdev::extract_min_r_version())) x else getRversion())
   )
-encoding: "UTF-8"
+exclusions: list(
+    "tests/testthat.R" = list(
+      unused_import_linter = Inf
+    ),
+    "tests" = list(
+      undesirable_function_linter = Inf
+    ),
+    "data-raw" = list(
+      missing_package_linter = Inf,
+      namespace_linter = Inf
+    )
+  )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,12 @@
-# linelist 0.0.2
+# linelist 1.0.0
 
 ## New features
 
 * Increased compatibility with dplyr is now documented and ensured through
 tests of all dplyr verbs on linelist objects as part of our testing & continuous
 integration system, as well as a new vignette: 
-<https://epiverse-trace.github.io/linelist/articles/compat-dplyr.html>
+<https://epiverse-trace.github.io/linelist/articles/compat-dplyr.html> 
+(@Bisaloo, #53)
 
 * A new selection helper is provided for tidyverse users, based on the existing
 selectors provided by the tidyselect package: `has_tag()` (@Bisaloo, #61). By 
@@ -18,10 +19,16 @@ names:
     dplyr::select(has_tag(c("id", "date_of_onset")))
   ```
 
+## Breaking changes
+
+* It is no longer possible to use `lost_tags_action()` within a pipeline. It 
+must now be set as a separate step. This makes the internal code more robust and
+clarifies what is part of the pipeline versus a global option (@Bisaloo, #79).
+
 * The `select_tags()` function is now deprecated to ensure we provide just one
 clear way to address a given issue and that our "happy path" is clearly
-signposted. If you were using this function, we now recommend using the more 
-explicit two-steps process:
+signposted (@Bisaloo, #61). If you were using this function, we now recommend 
+using the more explicit two-steps process:
 
   ```r
   # Deprecated
@@ -62,10 +69,11 @@ of the `select.linelist()` method. It is now recommend instead to use the new
 `dplyr::rename()`, including appropriate modification of the tags. (@Bisaloo, 
 #60)
 
+## Documentaiton
+
 * added a hex logo thanks to David Mascarina's contribution
 
 * added short lay description to README thanks to Emma Marty's contribution
-
 
 ## Bug fixes
 

--- a/R/linelist.R
+++ b/R/linelist.R
@@ -117,11 +117,6 @@
 #'
 #'     x %>%
 #'       select(starts_with("date"))
-#'
-#'     ## disable warnings on the fly
-#'     x %>%
-#'       lost_tags_action("none") %>%
-#'       select(starts_with("date"))
 #'   }
 #' }
 #'

--- a/R/lost_tags_action.R
+++ b/R/lost_tags_action.R
@@ -6,16 +6,14 @@
 #' but it can also accept a dataset as first argument, so that it can be used in
 #' pipelines as well.
 #'
-#' @param x either a `character`, or an optional `linelist` object; if a
-#'   `character`, it needs matching `warning` (default), `error` or `none` (see
-#'   below)
-#'
 #' @param action a `character` indicating the behaviour to adopt when tagged
 #'   variables have been lost: "error" (default) will issue an error; "warning"
 #'   will issue a warning; "none" will do nothing
 #'
 #' @param quiet a `logical` indicating if a message should be displayed; only
 #'   used outside pipelines
+#'   
+#' @param x deprecated
 #'
 #' @return if a a `linelist` is provided, it returns the object unchanged;
 #'   otherwise, returns `NULL`; the option itself is set in
@@ -47,35 +45,22 @@
 #' # reset to default: warning
 #' lost_tags_action()
 #'
-lost_tags_action <- function(x = NULL,
-                             action = c("warning", "error", "none"),
-                             quiet = FALSE) {
+lost_tags_action <- function(action = c("warning", "error", "none"),
+                             quiet = FALSE,
+                             x = NULL) {
   linelist_options <- options("linelist")$linelist
 
-  if (is.null(x)) {
-    x <- "warning"
+  action <- match.arg(action)
+  linelist_options$lost_tags_action <- action
+  options("linelist" = linelist_options)
+  if (!quiet) {
+    if (action == "warning") msg <- "Lost tags will now issue a warning."
+    if (action == "error") msg <- "Lost tags will now issue an error."
+    if (action == "none") msg <- "Lost tags will now be ignored."
+    message(msg)
   }
+  return(invisible(NULL))
 
-  # behaviour 1: action is passed through `x`
-  if (!is.null(x) && is.character(x) && length(x) == 1L) {
-    action <- match.arg(x, c("warning", "error", "none"))
-    linelist_options$lost_tags_action <- action
-    options("linelist" = linelist_options)
-    if (!quiet) {
-      if (action == "warning") msg <- "Lost tags will now issue a warning."
-      if (action == "error") msg <- "Lost tags will now issue an error."
-      if (action == "none") msg <- "Lost tags will now be ignored."
-      message(msg)
-    }
-    return(invisible(NULL))
-
-    # behaviour 2 (in pipeline): first argument is a dataset
-  } else {
-    action <- match.arg(action)
-    linelist_options$lost_tags_action <- action
-    options("linelist" = linelist_options)
-    return(x)
-  }
 }
 
 

--- a/R/lost_tags_action.R
+++ b/R/lost_tags_action.R
@@ -12,7 +12,7 @@
 #'
 #' @param quiet a `logical` indicating if a message should be displayed; only
 #'   used outside pipelines
-#'   
+#'
 #' @param x deprecated
 #'
 #' @return returns `NULL`; the option itself is set in `options("linelist")`
@@ -46,18 +46,18 @@
 lost_tags_action <- function(action = c("warning", "error", "none"),
                              quiet = FALSE,
                              x) {
-  
+
   if (!missing(x) || inherits(action, "linelist")) {
     stop(
       "Using `lost_tags_action()` in a pipeline is deprecated", call. = FALSE
     )
   }
-  
+
   linelist_options <- options("linelist")$linelist
 
   action <- match.arg(action)
   linelist_options$lost_tags_action <- action
-  options("linelist" = linelist_options)
+  options(linelist = linelist_options)
   if (!quiet) {
     if (action == "warning") msg <- "Lost tags will now issue a warning."
     if (action == "error") msg <- "Lost tags will now issue an error."

--- a/R/lost_tags_action.R
+++ b/R/lost_tags_action.R
@@ -47,7 +47,14 @@
 #'
 lost_tags_action <- function(action = c("warning", "error", "none"),
                              quiet = FALSE,
-                             x = NULL) {
+                             x) {
+  
+  if (!missing(x) || inherits(action, "linelist")) {
+    stop(
+      "Using `lost_tags_action()` in a pipeline is deprecated", call. = FALSE
+    )
+  }
+  
   linelist_options <- options("linelist")$linelist
 
   action <- match.arg(action)

--- a/R/lost_tags_action.R
+++ b/R/lost_tags_action.R
@@ -15,9 +15,7 @@
 #'   
 #' @param x deprecated
 #'
-#' @return if a a `linelist` is provided, it returns the object unchanged;
-#'   otherwise, returns `NULL`; the option itself is set in
-#'   `options("linelist")`
+#' @return returns `NULL`; the option itself is set in `options("linelist")`
 #'
 #' @export
 #'

--- a/man/linelist.Rd
+++ b/man/linelist.Rd
@@ -113,11 +113,6 @@ if (require(outbreaks)) {
 
     x \%>\%
       select(starts_with("date"))
-
-    ## disable warnings on the fly
-    x \%>\%
-      lost_tags_action("none") \%>\%
-      select(starts_with("date"))
   }
 }
 

--- a/man/lost_tags_action.Rd
+++ b/man/lost_tags_action.Rd
@@ -5,30 +5,22 @@
 \alias{get_lost_tags_action}
 \title{Check and set behaviour for lost tags}
 \usage{
-lost_tags_action(
-  x = NULL,
-  action = c("warning", "error", "none"),
-  quiet = FALSE
-)
+lost_tags_action(action = c("warning", "error", "none"), quiet = FALSE, x)
 
 get_lost_tags_action()
 }
 \arguments{
-\item{x}{either a \code{character}, or an optional \code{linelist} object; if a
-\code{character}, it needs matching \code{warning} (default), \code{error} or \code{none} (see
-below)}
-
 \item{action}{a \code{character} indicating the behaviour to adopt when tagged
 variables have been lost: "error" (default) will issue an error; "warning"
 will issue a warning; "none" will do nothing}
 
 \item{quiet}{a \code{logical} indicating if a message should be displayed; only
 used outside pipelines}
+
+\item{x}{deprecated}
 }
 \value{
-if a a \code{linelist} is provided, it returns the object unchanged;
-otherwise, returns \code{NULL}; the option itself is set in
-\code{options("linelist")}
+returns \code{NULL}; the option itself is set in \code{options("linelist")}
 }
 \description{
 This function determines the behaviour to adopt when tagged variables of a

--- a/tests/testthat/_snaps/compat-dplyr.md
+++ b/tests/testthat/_snaps/compat-dplyr.md
@@ -8,3 +8,8 @@
     The following tags have lost their variable:
      date_outcome:speed
 
+# Compatibility with dplyr::select()
+
+    The following tags have lost their variable:
+     date_outcome:speed
+

--- a/tests/testthat/_snaps/deprecated.md
+++ b/tests/testthat/_snaps/deprecated.md
@@ -2,7 +2,8 @@
 
     Code
       select_tags(x, "date_onset", "age")
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       `select_tags()` was deprecated in linelist 1.0.0.
       i This function is deprecated: use the two step `tags_df()` and `dplyr::select()` process instead
     Output
@@ -62,7 +63,8 @@
 
     Code
       select(x, tags = c("date_onset", "age"))
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       The `tags` argument of `select()` is deprecated as of linelist 1.0.0.
       i It is now recommended to leverage the `has_tag()` selection helper rather than this argument.
     Output

--- a/tests/testthat/test-lost_tags_action.R
+++ b/tests/testthat/test-lost_tags_action.R
@@ -17,3 +17,18 @@ test_that("tests for lost_tags_action", {
   lost_tags_action("warning", quiet = TRUE)
   expect_identical(get_lost_tags_action(), "warning")
 })
+
+test_that("deprecated pipeline option for lost_tags_action()", {
+
+  x <- make_linelist(cars, date_onset = "dist", date_outcome = "speed")
+  expect_error(
+    lost_tags_action(x),
+    "deprecated"
+  )
+  expect_error(
+    lost_tags_action(
+      x = "none"
+    )
+  )
+
+})

--- a/tests/testthat/test-lost_tags_action.R
+++ b/tests/testthat/test-lost_tags_action.R
@@ -11,10 +11,6 @@ test_that("tests for lost_tags_action", {
   lost_tags_action("error", quiet = TRUE)
   expect_identical(get_lost_tags_action(), "error")
 
-  x <- lost_tags_action(cars, "warning", quiet = TRUE)
-  expect_identical(get_lost_tags_action(), "warning")
-  expect_identical(x, cars)
-
   lost_tags_action("none", quiet = TRUE)
   expect_identical(get_lost_tags_action(), "none")
 

--- a/vignettes/linelist.Rmd
+++ b/vignettes/linelist.Rmd
@@ -340,13 +340,15 @@ x %>%
   select(1:2, has_tag("gender"))
 
 # hybrid selection - no warning
+lost_tags_action("none")
+
 x %>%
-  lost_tags_action("none") %>%
   select(1:2, has_tag("gender"))
 
 # hybrid selection - error due to lost tags
+lost_tags_action("error")
+
 x %>%
-  lost_tags_action("error") %>%
   select(1:2, has_tag("gender"))
 
 # note that `lost_tags_action` sets the behavior for any later operation, so we


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines 
- [x] A new item has been added to `NEWS.md`
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Fix #37 
