### PR TITLE
Use lowercase readme for custom dependencies in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3
 Config/testthat/parallel: true
-Config/Needs/README:
+Config/Needs/readme:
     incidence2 (>= 2.1.1),
     ggplot2
 Depends:


### PR DESCRIPTION
To align with the choice made in packagetemplate.
