### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -11,6 +11,9 @@ on:
       - '**/.lintr.R'
 
 name: lint-changed-files
+permissions:
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -12,8 +12,8 @@ on:
 
 name: lint-changed-files
 permissions:
-  contents: read
-  pull-requests: read
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/epiverse-trace/linelist/security/code-scanning/1](https://github.com/epiverse-trace/linelist/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents and pull request data, the permissions should be set to `contents: read` and `pull-requests: read`. This ensures the workflow adheres to the principle of least privilege.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`lint-changed-files`) to limit permissions for that job only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
