### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,6 +40,9 @@ on:
 
 name: R-CMD-check
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,6 +42,7 @@ name: R-CMD-check
 
 permissions:
   contents: read
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/epiverse-trace/linelist/security/code-scanning/2](https://github.com/epiverse-trace/linelist/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's purpose (testing R packages), the `contents: read` permission is sufficient for most steps. If specific steps require additional permissions, such as `pull-requests: write`, they can be defined at the job level.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. This ensures consistency and avoids inheriting repository defaults.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
